### PR TITLE
More shortcuts to resemble mac like experience

### DIFF
--- a/Mac-Shortcuts.ahk
+++ b/Mac-Shortcuts.ahk
@@ -114,3 +114,117 @@ Return
 #\::
 Send, ^\
 Return
+
+
+
+
+; Disable Windows key from opening Start menu
+~LWin Up::Return
+~RWin Up::Return
+
+; === DELETION ===
+; Delete line to the left (like Cmd+Backspace on Mac)
+#Backspace::
+Send, +{Home}{Backspace}
+Return
+
+; Delete word to the left (like Option+Backspace on Mac)
+!Backspace::
+Send, ^{Backspace}
+Return
+
+; Delete word to the right (like Option+Delete on Mac)
+!Delete::
+Send, ^{Delete}
+Return
+
+; === WORD/LINE NAVIGATION ===
+; Move by word (Option+Arrow on Mac)
+!Left::
+Send, ^{Left}
+Return
+
+!Right::
+Send, ^{Right}
+Return
+
+; Select by word (Option+Shift+Arrow on Mac)
+!+Left::
+Send, ^+{Left}
+Return
+
+!+Right::
+Send, ^+{Right}
+Return
+
+; Top/bottom of document (Cmd+Up/Down on Mac)
+#Up::
+Send, ^{Home}
+Return
+
+#Down::
+Send, ^{End}
+Return
+
+; Select to top/bottom of document
+#+Up::
+Send, ^+{Home}
+Return
+
+#+Down::
+Send, ^+{End}
+Return
+
+; === WINDOW/APP MANAGEMENT ===
+; Close window/app (Cmd+Q on Mac)
+#q::
+Send, !{F4}
+Return
+
+; Minimize window (Cmd+M on Mac)
+#m::
+Send, #{Down}
+Return
+
+; Switch apps (Cmd+Tab on Mac)
+#Tab::
+Send, !{Tab}
+Return
+
+; === BROWSER/APP SPECIFIC ===
+; Address bar (Cmd+L on Mac)
+#l::
+Send, ^l
+Return
+
+; Reopen closed tab (already have Cmd+Shift+T)
+; Next/previous tab
+#!Right::
+Send, ^{Tab}
+Return
+
+#!Left::
+Send, ^+{Tab}
+Return
+
+; === SEARCH/SPOTLIGHT ===
+; Spotlight-like search (Windows search)
+#Space::
+Send, #{s}
+Return
+
+; === MISC ===
+; Print (Cmd+P on Mac)
+#p::
+Send, ^p
+Return
+
+; Quit/Force quit
+#+q::
+Send, !{F4}
+Return
+
+; Cmd+Click = Ctrl+Click (for multi-select, opening links in new tabs, etc.)
+#LButton::
+Send, ^{Click}
+Return

--- a/README.md
+++ b/README.md
@@ -44,3 +44,24 @@ If you have suggestions for shortcuts that should be included, open an issue.
 | Hyperlink                | Windows + k                   | Ctrl + k                  |                                            |
 | Linebreak/Send           | Windows + Enter               | Ctrl + Enter              |                                            |
 | 1Password browser plugin | Windows + \                   | Ctrl + \                  |                                            |
+| Delete line to the left  | Windows + Backspace           | Shift + Home, Backspace   |                                            |
+| Delete word to the left  | Alt + Backspace               | Ctrl + Backspace          |                                            |
+| Delete word to the right | Alt + Delete                  | Ctrl + Delete             |                                            |
+| Move left by word        | Alt + Left arrow              | Ctrl + Left arrow         |                                            |
+| Move right by word       | Alt + Right arrow             | Ctrl + Right arrow        |                                            |
+| Select left by word      | Alt + Shift + Left arrow      | Ctrl + Shift + Left arrow |                                            |
+| Select right by word     | Alt + Shift + Right arrow     | Ctrl + Shift + Right arrow|                                            |
+| Go to top of document    | Windows + Up arrow            | Ctrl + Home               |                                            |
+| Go to end of document    | Windows + Down arrow          | Ctrl + End                |                                            |
+| Select to top of document| Windows + Shift + Up arrow    | Ctrl + Shift + Home       |                                            |
+| Select to end of document| Windows + Shift + Down arrow  | Ctrl + Shift + End        |                                            |
+| Close window/app         | Windows + q                   | Alt + F4                  |                                            |
+| Minimize window          | Windows + m                   | Windows + Down arrow      |                                            |
+| Switch apps              | Windows + Tab                 | Alt + Tab                 |                                            |
+| Address bar              | Windows + l                   | Ctrl + l                  |                                            |
+| Next tab                 | Windows + Alt + Right arrow   | Ctrl + Tab                |                                            |
+| Previous tab             | Windows + Alt + Left arrow    | Ctrl + Shift + Tab        |                                            |
+| Spotlight/Search         | Windows + Space               | Windows + s               |                                            |
+| Print                    | Windows + p                   | Ctrl + p                  |                                            |
+| Force quit               | Windows + Shift + q           | Alt + F4                  |                                            |
+| Cmd + Click              | Windows + Left Click          | Ctrl + Click              | Multi-select, open links in new tabs       |


### PR DESCRIPTION
## Mac-to-Windows Keyboard Shortcuts (AutoHotkey)

This AutoHotkey script remaps Windows keyboard shortcuts to match macOS behavior, making the transition between Mac and Windows seamless.

### Features:
- **Text Editing**: Cmd+Backspace to delete line, Option+Backspace/Delete for word deletion
- **Navigation**: Option+Arrow for word movement, Cmd+Up/Down for document start/end
- **Window Management**: Cmd+Q to close apps, Cmd+M to minimize, Cmd+Tab for app switching
- **Browser**: Cmd+L for address bar, Cmd+Option+Arrow for tab navigation
- **System**: Cmd+Space for search (Spotlight-like), Cmd+P for print
- **Mouse**: Cmd+Click acts as Ctrl+Click for multi-select and opening links in new tabs
- **Bonus**: Disables Windows key from accidentally opening the Start menu

### Installation:
1. Install [AutoHotkey](https://www.autohotkey.com/)
2. Save the script as `mac-shortcuts.ahk`
3. Double-click to run, or add to Windows Startup folder for automatic launch

### Key Mappings:
- `Win Key` = Cmd (⌘)
- `Alt Key` = Option (⌥)
- `Ctrl Key` = Ctrl (⌃)